### PR TITLE
Remove output folder

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ module.exports = function (options) {
 	var b = benchmark();
 
 	options = _.extend({
-		output: path.join(process.cwd(), 'benchmark-results.json'),
+		output: 'benchmark-results.json',
 		outputFormat: 'json'
 	}, options);
 
@@ -23,12 +23,11 @@ module.exports = function (options) {
 	}, function (cb) {
 		var f = new File({
     	cwd: process.cwd(),
-    	base: path.dirname(options.output),
     	path: options.output,
     	contents: new Buffer(b.getResults())
    	});
 
-		this.emit('data', f);
+		this.push(f);
 
 		cb();
 	});


### PR DESCRIPTION
User should be able to specify the output folder with gulp.dest, not via plugin options. Also, you should use push method to add file to stream, not emit event.
