### PR TITLE
this makes this work again with gulp.dest(...)

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function (options) {
    	});
 
 		this.emit('data', f);
-
+        this.push(f);
 		cb();
 	});
 };


### PR DESCRIPTION
_Warning_ i am new to gulp / (through|pipe|event-stream) paradigm.  But i believe that gulp-bench has a regression with gulp.dest(...)

So doing 

``` js
gulp.src('my-test.js', {read: false}).
    pipe(benchmark()).
    pipe(gulp.dest('.'));
```

wont work unless `this.push(f)` is present.

I am using gulp `3.8.8`
